### PR TITLE
get species in root

### DIFF
--- a/server/Routes/Species.js
+++ b/server/Routes/Species.js
@@ -31,7 +31,7 @@ async function getSpeciesDetails(scientificName) {
   }
 }
 
-router.get("/random", async (req, res) => {
+router.get("/", async (req, res) => {
   try {
     const gbifUrl =
       "https://api.gbif.org/v1/species/search?rank=species&kingdom=Animalia&class=Mammalia,Aves&limit=1000&offset=0";

--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,7 @@ const species =require("./Routes/Species");
 const cors =require('cors')
 const app = express();
 app.use(cors())
-app.use('/species',species)
+app.use(species)
 connection();
 const port =process.env.PORT || 5000
 app.listen(port,()=>{


### PR DESCRIPTION
### **User description**
changed the get endpoint


___

### **PR Type**
enhancement


___

### **Description**
- Changed species route to be accessible at root path.

- Updated API endpoint from `/species/random` to `/`.

- Modified Express app to mount species routes at root.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Species.js</strong><dd><code>Update species GET endpoint to root path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/Routes/Species.js

<li>Changed GET endpoint from <code>/random</code> to <code>/</code>.<br> <li> Now serves species data at the root of the router.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S76_Vigneshwaran_Capstone_WildNect/pull/8/files#diff-2a4340d0c3737dca44a63f7b4a4c4aef7e7aa579d342ea40012ad7f46440b078">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>Mount species routes at root in Express app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/index.js

<li>Changed species route mounting from <code>/species</code> to root.<br> <li> All species routes now accessible at the root path.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S76_Vigneshwaran_Capstone_WildNect/pull/8/files#diff-bcb729747c92e72c12e4590f736a334041a572c429756da8af60b6ab89c6be79">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>